### PR TITLE
TypeError: Exception::__construct(): Argument #1 ($message) must be of type string, array given

### DIFF
--- a/src/Error/ApiException.php
+++ b/src/Error/ApiException.php
@@ -1,0 +1,33 @@
+<?php
+
+/**
+ * Mailrelay API Client.
+ *
+ * @author Alfredo Ramos <alfredo.ramos@protonmail.com>
+ * @copyright 2021 Alfredo Ramos
+ * @license GPL-3.0-or-later
+ */
+
+namespace AlfredoRamos\Mailrelay\Error;
+
+class ApiException extends \Exception {
+    protected $_errors = null;
+
+    public function setErrors(array $data) : void {
+        $this->_errors = $data;
+    }
+
+    public function getErrors() : array {
+        return $this->_errors;
+    }
+
+    public function getFirstError() : string
+    {
+        if (!empty($this->_errors['base'][0])) {
+            return $this->_errors['base'][0];
+        }
+
+        return $this->_errors;
+    }
+
+}

--- a/src/Middleware/Error.php
+++ b/src/Middleware/Error.php
@@ -3,8 +3,8 @@
 /**
  * Mailrelay API Client.
  *
- * @author Alfredo Ramos <alfredo.ramos@proton.me>
- * @copyright 2021 Alfredo Ramos (https://alfredoramos.mx)
+ * @author Alfredo Ramos <alfredo.ramos@protonmail.com>
+ * @copyright 2021 Alfredo Ramos
  * @license GPL-3.0-or-later
  */
 
@@ -13,79 +13,85 @@ namespace AlfredoRamos\Mailrelay\Middleware;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
 
+use AlfredoRamos\Mailrelay\Error\ApiException;
+
 class Error {
-	/** @var callable */
-	private $nextHandler;
+    /** @var callable */
+    private $nextHandler;
 
-	/**
-	 * Error middleware constructor.
-	 *
-	 * @param callable $nextHandler Next handler to invoke.
-	 *
-	 * @return void
-	 */
-	public function __construct(callable $nextHandler) {
-		$this->nextHandler = $nextHandler;
-	}
+    /**
+     * Error middleware constructor.
+     *
+     * @param callable $nextHandler Next handler to invoke.
+     *
+     * @return void
+     */
+    public function __construct(callable $nextHandler) {
+        $this->nextHandler = $nextHandler;
+    }
 
-	/**
-	 * Invoke a handler.
-	 *
-	 * @param \Psr\Http\Message\RequestInterface $request The HTTP request.
-	 * @param array $options
-	 *
-	 * @return \GuzzleHttp\Promise\PromiseInterface Request promise.
-	 */
-	public function __invoke(RequestInterface $request, array $options) {
-		$handler = $this->nextHandler;
+    /**
+     * Invoke a handler.
+     *
+     * @param \Psr\Http\Message\RequestInterface $request The HTTP request.
+     * @param array $options
+     *
+     * @return \GuzzleHttp\Promise\PromiseInterface Request promise.
+     */
+    public function __invoke(RequestInterface $request, array $options) {
+        $handler = $this->nextHandler;
 
-		return $handler($request, $options)->then(function (ResponseInterface $response) {
-			return $this->checkError($response);
-		});
-	}
+        return $handler($request, $options)->then(function (ResponseInterface $response) {
+            return $this->checkError($response);
+        });
+    }
 
-	/**
-	 * Handle request errors.
-	 *
-	 * @return \Closure Function that accepts the next handler.
-	 */
-	public static function error() {
-		return function (callable $handler) {
-			return new self($handler);
-		};
-	}
+    /**
+     * Handle request errors.
+     *
+     * @return \Closure Function that accepts the next handler.
+     */
+    public static function error() {
+        return function (callable $handler) {
+            return new self($handler);
+        };
+    }
 
-	/**
-	 * Check request errors
-	 *
-	 * @param \Psr\Http\Message\ResponseInterface The HTTP response.
-	 *
-	 * @throws \ErrorException		If HTTP request returned an error.
-	 * @throws \RuntimeException	If HTTP request returned an unknown error.
-	 *
-	 * @return \Psr\Http\Message\ResponseInterface The HTTP response.
-	 */
-	public function checkError(ResponseInterface $response) {
-		if ($response->getStatusCode() < 400) {
-			return $response;
-		}
+    /**
+     * Check request errors
+     *
+     * @param \Psr\Http\Message\ResponseInterface The HTTP response.
+     *
+     * @throws \ErrorException      If HTTP request returned an error.
+     * @throws \RuntimeException    If HTTP request returned an unknown error.
+     * @throws \AlfredoRamos\Mailrelay\Error\ApiException If HTTP request returned multiple errors.
+     * @return \Psr\Http\Message\ResponseInterface The HTTP response.
+     */
+    public function checkError(ResponseInterface $response) {
+        if ($response->getStatusCode() < 400) {
+            return $response;
+        }
 
-		$body = (string) $response->getBody();
-		$responseBody = json_decode($body, true);
+        $body = (string) $response->getBody();
+        $responseBody = json_decode($body, true);
 
-		if (json_last_error() !== JSON_ERROR_NONE) {
-			$responseBody = $body;
-		}
+        if (json_last_error() !== JSON_ERROR_NONE) {
+            $responseBody = $body;
+        }
 
-		if (is_array($responseBody) && !empty($responseBody['error'])) {
-			$message = sprintf(
-				'[%d] Mailrelay API request failed: %2$s',
-				$response->getStatusCode(),
-				$responseBody['error']
-			);
-			throw new \ErrorException($message, $response->getStatusCode());
-		}
+        if (is_array($responseBody) && !empty($responseBody['error'])) {
+            $message = sprintf(
+                '[%d] Mailrelay API request failed: %2$s',
+                $response->getStatusCode(),
+                $responseBody['error']
+            );
+            throw new ApiException($message, $response->getStatusCode());
+        }
 
-		throw new \RuntimeException($responseBody, $response->getStatusCode());
-	}
+
+        $exception = new ApiException('API response contains errors', $response->getStatusCode());
+        $exception->setErrors($responseBody['errors'] ?? []);
+
+        throw $exception;
+    }
 }


### PR DESCRIPTION
Hello,


I noticed an error in the Middleware Error.
If the "error" key is not present it returns an exception that has as message the entire message received from MailRelay (an array).

The "error" key is not defined in the MailRelay API response, but the "errors" key is returned.


```php
TypeError: Exception::__construct(): Argument #1 ($message) must be of type string, array given
#0 app/vendor/alfredo-ramos/mailrelay-api-client/src/Middleware/Error.php(89): Exception->__construct()
#1 app/vendor/alfredo-ramos/mailrelay-api-client/src/Middleware/Error.php(43): AlfredoRamos\Mailrelay\Middleware\Error->checkError()
```


## How to reproduce the error?

Simply create a campaign and send a message to a group with no subscribers.

```php
            $response = $this->Client->api('Campaigns')->add([
                'analytics_utm_campaign' => 'newsletter',
                'sender_id' => 2,

                // Message
                'subject'   => 'TEST',
                'html'      => 'Hello, i'am a test <a style="display:none" href="{{%20unsubscribe_url%20}}">Disiscriviti</a>',

                'target'    => 'groups',
                'group_ids' => [ 0 =>$mygroupid ]
            ]);
```

The error from API is:

```json
{
  "errors": {
      "base": [
          "You need at least one subscriber to send this campaign"
      ]
  }
}
```

